### PR TITLE
fix:读取Excel在有表头的情况下进行toMap收集时，数据row的数量与表头对不上导致的下标越界问题修复

### DIFF
--- a/src/main/java/org/ttzero/excel/reader/Row.java
+++ b/src/main/java/org/ttzero/excel/reader/Row.java
@@ -1342,7 +1342,8 @@ public class Row {
         String key;
         int from = hasHeader ? hr.fc : fc, to = hasHeader ? hr.lc : lc;
         for (int i = from; i < to; i++) {
-            Cell c = cells[i];
+            // Cell c = cells[i];
+            Cell c = getCell(i);
             key = hasHeader ? names[i] : Integer.toString(i);
             // Ignore null key
             if (key == null) continue;


### PR DESCRIPTION
* 问题[#380](https://github.com/wangguanquan/eec/issues/380)