### PR TITLE
Dimension的bugfix和一个建议

### DIFF
--- a/src/main/java/org/ttzero/excel/reader/Dimension.java
+++ b/src/main/java/org/ttzero/excel/reader/Dimension.java
@@ -177,7 +177,7 @@ public class Dimension {
     public String toReferer() {
         char[] chars;
         if (lastRow > firstRow || lastColumn > firstColumn) {
-            int i = 0, c0 = firstColumn <= 26 ? 1 : firstColumn <= 702 ? 2 : 3 , r0 = stringSize(firstRow), c1 = lastRow <= 26 ? 1 : lastRow <= 702 ? 2 : 3, r1 = stringSize(lastRow);
+            int i = 0, c0 = firstColumn <= 26 ? 1 : firstColumn <= 702 ? 2 : 3 , r0 = stringSize(firstRow), c1 = lastColumn <= 26 ? 1 : lastColumn <= 702 ? 2 : 3, r1 = stringSize(lastRow);
             chars = new char[c0 + r0 + c1 + r1 + 5];
             chars[i++] = '$';
             System.arraycopy(int2Col(firstColumn), 0, chars, i, c0);

--- a/src/main/java/org/ttzero/excel/reader/Dimension.java
+++ b/src/main/java/org/ttzero/excel/reader/Dimension.java
@@ -16,6 +16,9 @@
 
 package org.ttzero.excel.reader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.ttzero.excel.entity.Sheet.int2Col;
 import static org.ttzero.excel.entity.Sheet.toCoordinate;
 import static org.ttzero.excel.reader.ExcelReader.coordinateToLong;
@@ -36,6 +39,7 @@ import static org.ttzero.excel.util.ExtBufferedWriter.stringSize;
  * @author guanquan.wang at 2019-12-20 10:07
  */
 public class Dimension {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Dimension.class);
 
     /**
      * 表示表格中支撑的最大行数。该值通常基于Excel中的最大行限制，即1,048,576。
@@ -113,6 +117,7 @@ public class Dimension {
             String refer = range.substring(i + 1);
             if (refer.isEmpty()) {
                 t = MAX_ROW;
+                LOGGER.warn("Empty reference detected. The range will include the entire column instead of a single cell.");
             } else {
                 t = coordinateToLong(refer);
             }

--- a/src/main/java/org/ttzero/excel/reader/Dimension.java
+++ b/src/main/java/org/ttzero/excel/reader/Dimension.java
@@ -36,6 +36,12 @@ import static org.ttzero.excel.util.ExtBufferedWriter.stringSize;
  * @author guanquan.wang at 2019-12-20 10:07
  */
 public class Dimension {
+
+    /**
+     * 表示表格中支撑的最大行数。该值通常基于Excel中的最大行限制，即1,048,576。
+     */
+    public static final long MAX_ROW = 1048576L << 16;
+
     /**
      * 起始行号 (one base)
      */
@@ -104,7 +110,12 @@ public class Dimension {
             t = coordinateToLong(range.substring(i + 1));
         } else {
             f = coordinateToLong(range.substring(0, i));
-            t = coordinateToLong(range.substring(i + 1));
+            String refer = range.substring(i + 1);
+            if (refer.isEmpty()) {
+                t = MAX_ROW;
+            } else {
+                t = coordinateToLong(refer);
+            }
         }
         return new Dimension((int) (f >> 16), (short) f, (int) (t >> 16), (short) t);
     }

--- a/src/main/java/org/ttzero/excel/reader/Dimension.java
+++ b/src/main/java/org/ttzero/excel/reader/Dimension.java
@@ -18,6 +18,7 @@ package org.ttzero.excel.reader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.ttzero.excel.manager.Const;
 
 import static org.ttzero.excel.entity.Sheet.int2Col;
 import static org.ttzero.excel.entity.Sheet.toCoordinate;
@@ -40,11 +41,6 @@ import static org.ttzero.excel.util.ExtBufferedWriter.stringSize;
  */
 public class Dimension {
     private static final Logger LOGGER = LoggerFactory.getLogger(Dimension.class);
-
-    /**
-     * 表示表格中支撑的最大行数。该值通常基于Excel中的最大行限制，即1,048,576。
-     */
-    public static final long MAX_ROW = 1048576L << 16;
 
     /**
      * 起始行号 (one base)
@@ -114,12 +110,10 @@ public class Dimension {
             t = coordinateToLong(range.substring(i + 1));
         } else {
             f = coordinateToLong(range.substring(0, i));
-            String refer = range.substring(i + 1);
-            if (refer.isEmpty()) {
-                t = MAX_ROW;
+            t = coordinateToLong(range.substring(i + 1));
+            if (t == 0L) {
+                t = (long) Const.Limit.MAX_ROWS_ON_SHEET << 16;
                 LOGGER.warn("Empty reference detected. The range will include the entire column instead of a single cell.");
-            } else {
-                t = coordinateToLong(refer);
             }
         }
         return new Dimension((int) (f >> 16), (short) f, (int) (t >> 16), (short) t);

--- a/src/test/java/org/ttzero/excel/reader/DimensionTest.java
+++ b/src/test/java/org/ttzero/excel/reader/DimensionTest.java
@@ -42,11 +42,11 @@ public class DimensionTest {
         assertEquals(d.firstColumn, 2);
         assertEquals(d.firstRow, 3);
         assertEquals(d.lastColumn, 2);
-        assertEquals(d.lastRow, 3);
+        assertEquals(d.lastRow, 1048576);
         assertEquals(d.width, 1);
-        assertEquals(d.height, 1);
+        assertEquals(d.height, 1048574);
 
-        assertEquals(d.toReferer(), "$B$3");
+        assertEquals(d.toReferer(), "$B$3:$B$1048576");
     }
 
     @Test public void testLastDim() {


### PR DESCRIPTION
目前使用`Dimension.of`时，对于`of("A1")`和`of("A1:")`的处理是一样的，并且目前还不支持自动匹配整列的操作。
所以是否可以将`of("A1:")`这种场景改为匹配整个A列？
改动了`Dimension$toReferer`方法，对于`of("A1:")`这种场景将匹配整个A列，而不是A1单元格了

匹配整列将会从指定行至`1048576`行，对于`1048576`的定义来自：
![image](https://github.com/user-attachments/assets/8072c96b-61a8-41d3-a6aa-b2a1ad9af020)

